### PR TITLE
Fix/correct partitons to small files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+script:
+  - ./gradlew test
+after_success:
+  - ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Read files on Hdfs.
 - **rewind_seconds** When you use Date format in input_path property, the format is executed by using the time which is Now minus this property.
 - **partition** when this is true, partition input files and increase task count. (default: `true`)
 - **num_partitions** number of partitions. (default: `Runtime.getRuntime().availableProcessors()`)
+- **skip_header_lines** Skip this number of lines first. Set 1 if the file has header line. (default: `0`)
 
 ## Example
 

--- a/src/main/java/org/embulk/input/hdfs/HdfsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/hdfs/HdfsFileInputPlugin.java
@@ -150,9 +150,11 @@ public class HdfsFileInputPlugin implements FileInputPlugin
         InputStream input;
         final HdfsPartialFile file = task.getFiles().get(taskIndex);
         try {
-            input = openInputStream(task, file);
             if (file.getStart() > 0 && task.getSkipHeaderLines() > 0) {
-                input = new SequenceInputStream(openHeaders(task, file), input);
+                input = new SequenceInputStream(getHeadersInputStream(task, file), openInputStream(task, file));
+            }
+            else {
+                input = openInputStream(task, file);
             }
         }
         catch (IOException e) {
@@ -173,7 +175,7 @@ public class HdfsFileInputPlugin implements FileInputPlugin
         };
     }
 
-    private InputStream openHeaders(PluginTask task, HdfsPartialFile partialFile) throws IOException
+    private InputStream getHeadersInputStream(PluginTask task, HdfsPartialFile partialFile) throws IOException
     {
         FileSystem fs = getFs(task);
         ByteArrayOutputStream header = new ByteArrayOutputStream();

--- a/src/main/java/org/embulk/input/hdfs/HdfsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/hdfs/HdfsFileInputPlugin.java
@@ -245,6 +245,7 @@ public class HdfsFileInputPlugin implements FileInputPlugin
     private List<HdfsPartialFile> allocateHdfsFilesToTasks(final PluginTask task, final FileSystem fs, final List<String> fileList)
             throws IOException
     {
+
         List<Path> pathList = Lists.transform(fileList, new Function<String, Path>()
         {
             @Nullable
@@ -264,6 +265,9 @@ public class HdfsFileInputPlugin implements FileInputPlugin
         long approximateNumPartitions =
                 (task.getApproximateNumPartitions() <= 0) ? Runtime.getRuntime().availableProcessors() : task.getApproximateNumPartitions();
         long partitionSizeByOneTask = totalFileLength / approximateNumPartitions;
+        if (partitionSizeByOneTask <= 0) {
+            partitionSizeByOneTask = 1;
+        }
 
         List<HdfsPartialFile> hdfsPartialFiles = new ArrayList<>();
         for (Path path : pathList) {

--- a/src/main/java/org/embulk/input/hdfs/HdfsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/hdfs/HdfsFileInputPlugin.java
@@ -66,8 +66,8 @@ public class HdfsFileInputPlugin implements FileInputPlugin
         @ConfigDefault("-1")      // Default: Runtime.getRuntime().availableProcessors()
         public long getApproximateNumPartitions();
 
-        @Config("skip_header_lines")
-        @ConfigDefault("0")
+        @Config("skip_header_lines") // Skip this number of lines first. Set 1 if the file has header line.
+        @ConfigDefault("0")          // The reason why the parameter is configured is that this plugin splits files.
         public int getSkipHeaderLines();
 
         public List<HdfsPartialFile> getFiles();
@@ -152,7 +152,7 @@ public class HdfsFileInputPlugin implements FileInputPlugin
         try {
             input = openInputStream(task, file);
             if (file.getStart() > 0 && task.getSkipHeaderLines() > 0) {
-                input = new SequenceInputStream(openWithHeaders(task, file), input);
+                input = new SequenceInputStream(openHeaders(task, file), input);
             }
         }
         catch (IOException e) {
@@ -173,7 +173,7 @@ public class HdfsFileInputPlugin implements FileInputPlugin
         };
     }
 
-    private InputStream openWithHeaders(PluginTask task, HdfsPartialFile partialFile) throws IOException
+    private InputStream openHeaders(PluginTask task, HdfsPartialFile partialFile) throws IOException
     {
         FileSystem fs = getFs(task);
         ByteArrayOutputStream header = new ByteArrayOutputStream();

--- a/src/test/java/org/embulk/input/hdfs/TestHdfsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/hdfs/TestHdfsFileInputPlugin.java
@@ -159,6 +159,7 @@ public class TestHdfsFileInputPlugin
         return Exec.newConfigSource()
                 .set("path", path.toString())
                 .set("config", hdfsLocalFSConfig())
+                .set("skip_header_lines", 1)
                 .set("parser", parserConfig(schemaConfig()));
     }
 


### PR DESCRIPTION
- Do not split if the file is smaller than 1 byte
- Fix a bug: add `skip_header_lines` option
