### PR TITLE
Avoid DataException even if all files are empty

### DIFF
--- a/src/main/java/org/embulk/input/hdfs/HdfsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/hdfs/HdfsFileInputPlugin.java
@@ -151,8 +151,8 @@ public class HdfsFileInputPlugin
     {
         long totalFileLength = calcTotalFilesLength(statusList);
         if (totalFileLength <= 0) {
-            // TODO: skip this error because other file input plugins have no errors if files are empty.
-            throw new DataException("embulk-input-hdfs: All files are empty: " + task.getPath());
+            logger.warn("embulk-input-hdfs: All files are empty: {}", task.getPath());
+            return TargetFileInfoList.builder(task).build();
         }
 
         long partitionSizeByOneTask = calcApproximatePartitionSizeByOneTask(task, totalFileLength);


### PR DESCRIPTION
No error happens in file-input plugins (like embulk-input-s3, embulk-input-local_file) if all target files are empty. So, I think this plugin should align the interface.
